### PR TITLE
Post-publish cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* corrected module source in the example
+* removed `CODEOWNERS` and `CONTRIBUTING.md` from the root of the repo
+
 ## 0.1.0 (August 15, 2022)
 
 * Initial release

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @tradeparadigm/infra

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-# Welcome to our contributing guide
-
-TODO: contributing guide

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For example:
 
 ```hcl
 module "lambda" {
-  source = "tradeparadigm/aws/ecr-repo-lambda"
+  source = "tradeparadigm/ecr-repo-lambda/aws"
 
   managed_repo_prefixes = [
     "backend/",

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@
  *
  * ```hcl
  * module "lambda" {
- *   source = "tradeparadigm/aws/ecr-repo-lambda"
+ *   source = "tradeparadigm/ecr-repo-lambda/aws"
  *
  *   managed_repo_prefixes = [
  *     "backend/",


### PR DESCRIPTION
Turns out, the published module source is a bit different than
anticipated. See [module page][1] in Terraform Registry.

* correcting module source in the example, after publish
* removed `CODEOWNERS` and `CONTRIBUTING.md` from the root of the repo

[1]: https://registry.terraform.io/modules/tradeparadigm/ecr-repo-lambda/aws/latest