### PR TITLE
[feat][bugfix] Switch runtime to python3.12, and other random fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,13 +6,13 @@ exclude: >
 default_stages: [commit]
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.5.0
   hooks:
   - id: check-merge-conflict
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 23.12.1
   hooks:
   - id: black
     args:
@@ -20,13 +20,13 @@ repos:
     - --include='\.pyi?$'
     - --target-version=py310
     - --line-length=99
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 4.0.1
+- repo: https://github.com/pycqa/flake8
+  rev: 6.1.0
   hooks:
   - id: flake8
     additional_dependencies: [flake8-isort]
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.73.0
+  rev: v1.88.2
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -13,8 +13,6 @@ sections:
   hide: []
   show: []
 
-content: ""
-
 output:
   file: "README.md"
   mode: replace

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This module manages AWS Lambda which creates private ECR repositories
 whenever an attempt to push to a non-existing repository is logged in
 CloudTrail. Since `docker push` attempt five times, the repository will
-be created before all retry attempts exhaused, if lambda is working
+be created before all retry attempts exhausted, if lambda is working
 correctly 😉.
 
 ## Usage
@@ -64,7 +64,7 @@ module "lambda" {
 | <a name="input_log_retention_days"></a> [log_retention_days](#input_log_retention_days) | Number of days to retain AWS Lambda logs. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. | `number` | `14` | no |
 | <a name="input_managed_repo_prefixes"></a> [managed_repo_prefixes](#input_managed_repo_prefixes) | List of managed ECR repo prefixes Lambda can create repos for. | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input_name) | AWS Lambda name. Region will be appended as suffix: `<name>-<aws_region>`. | `string` | `"create-ecr-repo"` | no |
-| <a name="input_repo_lifecycle_policy"></a> [repo_lifecycle_policy](#input_repo_lifecycle_policy) | ECR repository policy added to every repo Lambda creates. | `string` | `"{\n  \"rules\": [\n    {\n      \"rulePriority\": 10,\n      \"description\": \"Only keep 20 most recent untagged images.\",\n      \"selection\": {\n        \"tagStatus\": \"untagged\",\n        \"countType\": \"imageCountMoreThan\",\n        \"countNumber\": 20\n      },\n      \"action\": {\n        \"type\": \"expire\"\n      }\n    }\n}\n"` | no |
+| <a name="input_repo_lifecycle_policy"></a> [repo_lifecycle_policy](#input_repo_lifecycle_policy) | ECR repository policy added to every repo Lambda creates. | `string` | `"{\n  \"rules\": [\n    {\n      \"rulePriority\": 10,\n      \"description\": \"Only keep 20 most recent untagged images.\",\n      \"selection\": {\n        \"tagStatus\": \"untagged\",\n        \"countType\": \"imageCountMoreThan\",\n        \"countNumber\": 20\n      },\n      \"action\": {\n        \"type\": \"expire\"\n      }\n    }\n  ]\n}\n"` | no |
 | <a name="input_repo_scan_on_push"></a> [repo_scan_on_push](#input_repo_scan_on_push) | Toggles Scan on push on repos Lambda creates. | `bool` | `true` | no |
 | <a name="input_repo_tags"></a> [repo_tags](#input_repo_tags) | ECR repo tags added to every repo Lambda creates. | `map(string)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input_tags) | Tags to apply to created AWS resources. | `map(string)` | `{}` | no |

--- a/files/create-ecr-repo/src/handler.py
+++ b/files/create-ecr-repo/src/handler.py
@@ -34,6 +34,7 @@ def lifecycle_policy():
         try:
             json.loads(policy)
         except ValueError as err:
+            logger.error("Failed to parse REPO_LIFECYCLE_POLICY: %s", err)
             return None
     return policy
 
@@ -45,6 +46,7 @@ def repo_tags():
         try:
             tags = [{"Key": k, "Value": v} for (k, v) in json.loads(tags_env).items()]
         except ValueError as err:
+            logger.error("Failed to parse REPO_TAGS: %s", err)
             return []
     return tags
 

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@
  * This module manages AWS Lambda which creates private ECR repositories
  * whenever an attempt to push to a non-existing repository is logged in
  * CloudTrail. Since `docker push` attempt five times, the repository will
- * be created before all retry attempts exhaused, if lambda is working
+ * be created before all retry attempts exhausted, if lambda is working
  * correctly 😉.
  *
  * ## Usage
@@ -46,7 +46,7 @@ resource "aws_lambda_function" "this" {
   description      = "Creates ECR repo when push failed due to missing repo."
   role             = aws_iam_role.this.arn
   handler          = "handler.run"
-  runtime          = "python3.9"
+  runtime          = "python3.12"
   source_code_hash = data.archive_file.this.output_base64sha256
 
   reserved_concurrent_executions = var.lambda_concurrency

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "image_tag_mutability" {
   nullable    = false
   validation {
     condition     = contains(["MUTABLE", "IMMUTABLE"], var.image_tag_mutability)
-    error_message = "The image_tag_mutability value must be onde of \"MUTABLE\" or \"IMMUTABLE\"."
+    error_message = "The image_tag_mutability value must be one of \"MUTABLE\" or \"IMMUTABLE\"."
   }
 }
 
@@ -62,9 +62,10 @@ variable "repo_lifecycle_policy" {
             "type": "expire"
           }
         }
+      ]
     }
   DEFAULT
-  nullable    = false
+  nullable    = true
 }
 
 variable "repo_tags" {


### PR DESCRIPTION
With AWS continually deprecating runtimes for old Python versions, let's switch from Python 3.9 to Python 3.12. And while we are at it, let fix other issues.

* fixing typos
* updating AWS Lambda runtime from `python3.9` to `python3.12`
* updating pre-commit hooks repo versions
* removing duplicate `content` key in TF Docs config
* fixing default value of `var.repo_lifecycle_policy` (fixes #2)
* making `var.repo_lifecycle_policy` nullable (fixes #2)
* adding error log message when JSON parsing fails (fixes #2)