### PR TITLE
Extend timeout and make configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* make lambda timeout configurable and increase default to 10s
+
 ## 0.3.0 (May 14, 2024)
 
 * adding repo policy ([#5])

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,7 @@ resource "aws_lambda_function" "this" {
   role             = aws_iam_role.this.arn
   handler          = "handler.run"
   runtime          = "python3.12"
+  timeout          = var.lambda_timeout
   source_code_hash = data.archive_file.this.output_base64sha256
 
   reserved_concurrent_executions = var.lambda_concurrency
@@ -56,7 +57,7 @@ resource "aws_lambda_function" "this" {
       MANAGED_REPO_PREFIXES = join(",", var.managed_repo_prefixes)
       IMAGE_TAG_MUTABILITY  = var.image_tag_mutability
       REPO_LIFECYCLE_POLICY = var.repo_lifecycle_policy
-      REPO_POLICY           = var.repo_policy 
+      REPO_POLICY           = var.repo_policy
       REPO_TAGS             = jsonencode(local.repo_tags)
       REPO_SCAN_ON_PUSH     = tostring(var.repo_scan_on_push)
     }

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,13 @@ variable "lambda_concurrency" {
   nullable    = false
 }
 
+variable "lambda_timeout" {
+  type        = number
+  description = "AWS Lambda timeout in seconds"
+  default     = 10
+  nullable    = false
+}
+
 variable "log_retention_days" {
   type        = number
   description = "Number of days to retain AWS Lambda logs. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire."


### PR DESCRIPTION
Recreation of https://github.com/tradeparadigm/terraform-aws-ecr-repo-lambda/pull/8 with signed commits

Fixes https://github.com/tradeparadigm/terraform-aws-ecr-repo-lambda/issues/7

Increase the lambda timeout to 10s and make configurable. The terraform provider's default of 3s is too short, which can result in ECR repos being created without resource policies being applied.